### PR TITLE
Difference in -> difference between

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1961,7 +1961,7 @@ a good summary statistic.
 
 An {\bf effect size} is a summary statistic intended to describe (wait
 for it) the size of an effect.  For example, to describe the
-difference between two groups, one obvious choice is the difference in
+difference between two groups, one obvious choice is the difference between
 the means.  \index{effect size}
 
 Mean pregnancy length for first babies is 38.601; for
@@ -2000,7 +2000,7 @@ def CohenEffectSize(group1, group2):
     return d
 \end{verbatim}
 
-In this example, the difference in means is 0.029 standard deviations,
+In this example, the difference between the means is 0.029 standard deviations,
 which is small.  To put that in perspective, the difference in
 height between men and women is about 1.7 standard deviations (see
 \url{https://en.wikipedia.org/wiki/Effect_size}).
@@ -2706,7 +2706,7 @@ provided by Pmf.
 
 \begin{exercise}
 I started with the question, ``Are first babies more likely
-to be late?''  To address it, I computed the difference in
+to be late?''  To address it, I computed the difference between the
 means between groups of babies, but I ignored the possibility
 that there might be a difference between first babies and
 others {\em for the same woman}.
@@ -6589,12 +6589,12 @@ considered borderline.  So in this example I conclude that the
 data do not provide strong evidence that the coin is biased or not.
 
 
-\section{Testing a difference in means}
+\section{Testing a difference between means}
 \label{testdiff}
 \index{mean!difference in}
 
-One of the most common effects to test is a difference in mean
-between two groups.  In the NSFG data, we saw that the mean pregnancy
+One of the most common effects to test is a difference between means
+of two groups.  In the NSFG data, we saw that the mean pregnancy
 length for first babies is slightly longer, and the mean birth weight
 is slightly smaller.  Now we will see if those effects are
 statistically significant.
@@ -6632,7 +6632,7 @@ class DiffMeansPermute(thinkstats2.HypothesisTest):
 \end{verbatim}
 
 \verb"data" is a pair of sequences, one for each
-group.  The test statistic is the absolute difference in the means.
+group.  The test statistic is the absolute difference between the means.
 \index{HypothesisTest}
 
 \verb"MakeModel" records the sizes of the groups, \verb"n" and
@@ -6712,7 +6712,7 @@ significant.
 Choosing the best test statistic depends on what question you are
 trying to address.  For example, if the relevant question is whether
 pregnancy lengths are different for first
-babies, then it makes sense to test the absolute difference in means,
+babies, then it makes sense to test the absolute difference between the means,
 as we did in the previous section.
 \index{test statistic}
 \index{pregnancy length}
@@ -12358,7 +12358,7 @@ distribution?
 
 \begin{exercise}
 In Section~\ref{usingCLT} we used the Central Limit Theorem to find
-the sampling distribution of the difference in means, $\delta$, under
+the sampling distribution of the difference between the means, $\delta$, under
 the null hypothesis that both samples are drawn from the same
 population.
 \index{null hypothesis}
@@ -12374,7 +12374,7 @@ the samples are drawn from different populations.
 \index{confidence interval}
 
 Compute this distribution and use it to calculate the standard error
-and a 90\% confidence interval for the difference in means.
+and a 90\% confidence interval for the difference between the means.
 \end{exercise}
 
 
@@ -12396,7 +12396,7 @@ reported a score of 3.57 with standard error 0.28.  Women reported
 1.91, on average, with standard error 0.32.
 \index{standard error}
 
-Compute the sampling distribution of the gender gap (the difference in
+Compute the sampling distribution of the gender gap (the difference between the
 means), and test whether it is statistically significant.  Because you
 are given standard errors for the estimated means, you don't need to
 know the sample size to figure out the sampling distributions.


### PR DESCRIPTION
When discussing discreet things "distance between" is preferred. "Distance in" is preferred for more abstract or less discrete ideas. For example:
distance between the means
distance between the groups
distance in the height of the groups
distance in the age of the groups
distance between his and her ages.
distance in their ages -> doesn't sound bad, but not as good as "between."
This becomes a bit more problematic with the phrasing "distance in means" where means can mean a discrete thing, like the, ahem, "average" or it can mean an abstract thing like "the way of doing something." Sure you can get it from context, but the reader who is aware of the difference has to double check every time.